### PR TITLE
Minor config improvements

### DIFF
--- a/src/main/java/com/artillexstudios/axplayerwarps/guis/impl/RateWarpGui.java
+++ b/src/main/java/com/artillexstudios/axplayerwarps/guis/impl/RateWarpGui.java
@@ -67,10 +67,10 @@ public class RateWarpGui extends GuiFrame {
             AxPlayerWarps.getThreadedQueue().submit(() -> {
                 if (isFavorite) {
                     AxPlayerWarps.getDatabase().removeFromFavorites(player, warp);
-                    MESSAGEUTILS.sendLang(player, "favorite.remove");
+                    MESSAGEUTILS.sendLang(player, "favorite.remove", Map.of("%warp%", warp.getName()));
                 } else {
                     AxPlayerWarps.getDatabase().addToFavorites(player, warp);
-                    MESSAGEUTILS.sendLang(player, "favorite.add");
+                    MESSAGEUTILS.sendLang(player, "favorite.add", Map.of("%warp%", warp.getName()));
                 }
                 Scheduler.get().run(this::open);
             });

--- a/src/main/java/com/artillexstudios/axplayerwarps/warps/Warp.java
+++ b/src/main/java/com/artillexstudios/axplayerwarps/warps/Warp.java
@@ -262,6 +262,10 @@ public class Warp {
     }
 
     public CompletableFuture<Boolean> isDangerous() {
+        if (!CONFIG.getBoolean("check-unsafe-warps", true)) {
+            return CompletableFuture.completedFuture(false);
+        }
+
         return PaperUtils.getChunkAtAsync(location).thenApply((chunk) -> {
             int x = location.getBlockX() & 15;
             int y = location.getBlockY();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -70,6 +70,9 @@ warp-naming:
 # PLAYER_HEAD will default to the owner's skull (note: sometimes it may not load)
 default-material: "PLAYER_HEAD"
 
+# should warp location be checked to see if they are unsafe?
+check-unsafe-warps: true
+
 # how much time do players have to confirm if a warp is unsafe or paid
 confirmation-milliseconds: 10000
 


### PR DESCRIPTION
**Changelog:**
- Added `check-unsafe-warps` to config to allow disabling danger check if unwanted. _This is particularly useful for servers with keep inventory on where there is minimal concern of a warp being unsafe_
- Made `favorite.add` and `favorite.remove` messages support `%warp%` placeholder

This PR has been partially tested by removing missing economy dependencies