### PR TITLE
Add option to ignore case for disallowed warp names

### DIFF
--- a/src/main/java/com/artillexstudios/axplayerwarps/utils/SimpleRegex.java
+++ b/src/main/java/com/artillexstudios/axplayerwarps/utils/SimpleRegex.java
@@ -1,10 +1,15 @@
 package com.artillexstudios.axplayerwarps.utils;
 
 import java.util.List;
+import java.util.Locale;
 
 public class SimpleRegex {
 
     public static boolean matches(List<String> list, String cmd) {
+        return matches(list, cmd, false);
+    }
+
+    public static boolean matches(List<String> list, String cmd, boolean ignoreCase) {
         for (String string : list) {
             if (string.isBlank()) continue;
             RegexType regexType = RegexType.EQUALS;
@@ -23,6 +28,10 @@ public class SimpleRegex {
                 regexType = RegexType.ENDS_WITH;
             }
 
+            if (ignoreCase) {
+                cmd = cmd.toLowerCase(Locale.ROOT);
+                string = string.toLowerCase(Locale.ROOT);
+            }
             boolean result = switch (regexType) {
                 case CONTAINS -> cmd.contains(string);
                 case STARTS_WITH -> cmd.endsWith(string);

--- a/src/main/java/com/artillexstudios/axplayerwarps/utils/WarpNameUtils.java
+++ b/src/main/java/com/artillexstudios/axplayerwarps/utils/WarpNameUtils.java
@@ -34,7 +34,7 @@ public class WarpNameUtils {
             }
         }
 
-        if (SimpleRegex.matches(CONFIG.getStringList("warp-naming.disallowed"), name)) {
+        if (SimpleRegex.matches(CONFIG.getStringList("warp-naming.disallowed"), name, CONFIG.getBoolean("warp-naming.disallowed-ignore-case"))) {
             return ValidationResult.DISALLOWED;
         }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -76,6 +76,7 @@ warp-naming:
   # - '*name*' #  disallows text containing 'name'
   disallowed:
     - "*banned_warp_name*"
+  disallowed-ignore-case: false
 
 # worlds where creating warps is disallowed
 # you can use the regex options from the section above (warp-naming.disallowed)


### PR DESCRIPTION
Adds the config option `warp-naming.disallowed-ignore-case` to ignore case for the `disallowed` list. When true, disallowed names can't be bypassed using a mix of upper and lower case.